### PR TITLE
fix encoding adding extra nulls at the end of some tokens

### DIFF
--- a/src/main/java/ai/tunib/tokenizer/GPT2Tokenizer.java
+++ b/src/main/java/ai/tunib/tokenizer/GPT2Tokenizer.java
@@ -186,7 +186,7 @@ public class GPT2Tokenizer {
         while (matcher.find()) {
             String match = matcher.group();
             StringBuilder unicodeBuilder = new StringBuilder();
-            for (byte b : StandardCharsets.UTF_8.encode(match).array()) {
+            for (byte b : match.getBytes(StandardCharsets.UTF_8)) {
                 unicodeBuilder.append(this.byte2unicode.get((int)b));
             }
             unicodes.add(unicodeBuilder.toString());

--- a/src/test/java/ai/tunib/tokenizer/GPT2TokenizerTest.java
+++ b/src/test/java/ai/tunib/tokenizer/GPT2TokenizerTest.java
@@ -8,6 +8,9 @@ public class GPT2TokenizerTest {
     private final String encodingExample = "Hello my name is Kevin.";
     private final List<Integer> decodingExample = List.of(15496, 616, 1438, 318, 7939, 13);
 
+    private final String encodingLongTextExample = "interesting";
+    private final List<Integer> decodingLongTextExample = List.of(47914);
+
     @Test
     public void testEncoding() {
         GPT2Tokenizer tokenizer = GPT2Tokenizer.fromPretrained("tokenizers/gpt2");
@@ -20,5 +23,12 @@ public class GPT2TokenizerTest {
         GPT2Tokenizer tokenizer = GPT2Tokenizer.fromPretrained("tokenizers/gpt2");
         String result = tokenizer.decode(decodingExample);
         Assertions.assertEquals(encodingExample, result);
+    }
+
+    @Test
+    public void testLongWord() {
+        GPT2Tokenizer tokenizer = GPT2Tokenizer.fromPretrained("tokenizers/gpt2");
+        List<Integer> result = tokenizer.encode(encodingLongTextExample);
+        Assertions.assertEquals(decodingLongTextExample, result);
     }
 }


### PR DESCRIPTION
StandardCharsets.UTF_8.encode().array() returns the underlying bytebuffer that might have extra capacity at the end of the buffer. This results the returned array having extra nulls that were not intended to be encoded. See the added test case.

(https://stackoverflow.com/questions/42912994/null-characters-added-when-a-string-is-encoded-into-utf-8-bytes)